### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -161,14 +161,19 @@ serve(async (req) => {
 
     // Always 200 to Stripe for events we accepted into the ledger; otherwise
     // Stripe will keep retrying forever and we'd build up a flood.
-    return new Response(JSON.stringify({ received: true, error: processingError }), {
-      status: 200,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({
+        received: true,
+        error: processingError ? "processing_failed" : null,
+      }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
   } catch (error: unknown) {
     console.error("[stripe-webhook] Unhandled error:", error);
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return new Response(JSON.stringify({ error: message }), {
+    return new Response(JSON.stringify({ error: "Invalid webhook request" }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
       status: 400,
     });


### PR DESCRIPTION
Potential fix for [https://github.com/prettyinpurple2021/solosuccess-academy/security/code-scanning/4](https://github.com/prettyinpurple2021/solosuccess-academy/security/code-scanning/4)

The fix is to stop including exception-derived details in HTTP responses and return only a generic status payload. Keep detailed diagnostics in server logs and (optionally) persisted ledger fields for internal operations.

Best single fix without changing functionality:
- In `supabase/functions/stripe-webhook/index.ts`, at the response for accepted ledger events (around line 164), replace `error: processingError` with a non-sensitive generic value (for example, `error: processingError ? "processing_failed" : null`).
- In the outer catch (around lines 170–172), stop returning `error.message`; return a generic message like `"Invalid webhook request"`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Avoid exposing internal error details in the Stripe webhook HTTP responses.

Bug Fixes:
- Return a generic processing status in successful Stripe webhook responses instead of including raw error objects.
- Replace detailed error messages in Stripe webhook error responses with a generic "Invalid webhook request" message to prevent information leakage.